### PR TITLE
Make svgcairo build with Cabal 2.0

### DIFF
--- a/svgcairo.cabal
+++ b/svgcairo.cabal
@@ -1,5 +1,5 @@
 Name:           svgcairo
-Version:        0.13.1.1
+Version:        0.13.1.2
 License:        BSD3
 License-file:   COPYING
 Copyright:      (c) 2001-2010 The Gtk2Hs Team
@@ -30,7 +30,7 @@ Source-Repository head
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 1.25,
+                 Cabal >= 1.24 && < 2.1,
                  gtk2hs-buildtools >= 0.13.1.0 && < 0.14
 
 Library


### PR DESCRIPTION
svgcairo can not be built with Cabal 2.0 according to the .cabal file. 

It is also not contained in any stackage resolver. Is it possible to add it there?