### PR TITLE
Support upto GHC-8.8.1, cabal 3.0.0.0 and bump version to 0.13.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 env:
- - CABALVER=1.24 GHCVER=7.8.3
- - CABALVER=1.24 GHCVER=7.8.4
- - CABALVER=1.24 GHCVER=7.10.1
- - CABALVER=1.24 GHCVER=7.10.2
  - CABALVER=1.24 GHCVER=7.10.3
  - CABALVER=1.24 GHCVER=8.0.1
+ - CABALVER=1.24 GHCVER=8.0.2
+ - CABALVER=2.0 GHCVER=8.2.1
+ - CABALVER=2.0 GHCVER=8.2.2
+ - CABALVER=2.2 GHCVER=8.4.1
+ - CABALVER=2.2 GHCVER=8.4.4
+ - CABALVER=2.4 GHCVER=8.6.1
+ - CABALVER=2.4 GHCVER=8.6.5
+ - CABALVER=3.0 GHCVER=8.8.1
 
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
@@ -12,23 +16,27 @@ before_install:
  - travis_retry sudo apt-get --no-install-recommends install librsvg2-dev
  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
  - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
- - |
-   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.10" ] || [ ${GHCVER%.*} = "8.0" ]; then
-     travis_retry sudo apt-get install happy-1.19.4 alex-3.1.3
-     export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
-   else
-     travis_retry sudo apt-get install happy alex
-   fi
 
 install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - cabal update
- - cabal install Cabal
+ - |
+   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "8.8" ]; then
+     cabal build Cabal
+   else
+     cabal install Cabal
+   fi
+ - cabal install happy alex
  - cabal install gtk2hs-buildtools
 
 script:
-  - cabal install
+ - |
+   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "8.8" ]; then
+     cabal build
+   else
+     cabal install
+   fi
 
 notifications:
   irc:

--- a/svgcairo.cabal
+++ b/svgcairo.cabal
@@ -1,8 +1,8 @@
 Name:           svgcairo
-Version:        0.13.2.0
+Version:        0.13.2.1
 License:        BSD3
 License-file:   COPYING
-Copyright:      (c) 2001-2010 The Gtk2Hs Team
+Copyright:      (c) 2001-2019 The Gtk2Hs Team
 Author:         Duncan Coutts
 Maintainer:     gtk2hs-users@lists.sourceforge.net
 Build-Type:     Custom
@@ -14,7 +14,9 @@ Synopsis:       Binding to the libsvg-cairo library.
 Description:    Svgcairo is used to render SVG with cairo.
 
 Category:       Graphics
-Tested-With:    GHC == 6.10.4, GHC == 6.12.3, GHC == 7.0.4, GHC == 7.2.1
+Tested-With:    GHC == 7.10.3, GHC == 8.0.1, GHC == 8.0.2, GHC == 8.2.1,
+                GHC == 8.2.2,  GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.1,
+                GHC == 8.6.5,  GHC == 8.8.1
 x-Types-Forward: *Graphics.UI.GtkInternals
 x-Types-Destructor: objectUnrefFromMainloop
 Extra-Source-Files: svgcairo.h
@@ -23,14 +25,14 @@ Data-Dir:		demo
 Data-Files:		Makefile
                 Svg2Png.hs
                 SvgViewer.hs
-				
+
 Source-Repository head
   type:         git
   location:     https://github.com/gtk2hs/svgcairo
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 2.5,
+                 Cabal >= 1.24 && < 3.1,
                  gtk2hs-buildtools >= 0.13.2.0 && < 0.14
 
 Library
@@ -41,10 +43,10 @@ Library
         cpp-options:    -U__BLOCKS__ -D__attribute__(A)= -D_Nullable= -D_Nonnull=
         exposed-modules:
           Graphics.Rendering.Cairo.SVG
-		
+
         default-language:       Haskell2010
         default-extensions:     ForeignFunctionInterface
-		
+
         Include-dirs: .
         x-c2hs-Header:  svgcairo.h
         pkgconfig-depends: librsvg-2.0 >= 2.16.0


### PR DESCRIPTION
This PR allows to compile the `svgcairo` library with newer GHC versions and their recommended cabal versions.

There are no changes to the logic of the libraries. I only changed the .cabal and the travis.yaml file.

Most of the changes I did in the travis.yaml file: 

- I don't test any more **all** subreleases of a main GHC version: eg GHC 8.4 has versions 8.4.1, 8.4.2, 8.4.3 and 8.4.4. I only test the first (8.4.1) and the last (8.4.4).
- Cabal 3.0.0.0 also needed some changes in the yaml logic.
- I removed the tests to GHC versions earlier than 7.10.3.  