### PR TITLE
Correct cpp-options for both linux/darwin

### DIFF
--- a/svgcairo.cabal
+++ b/svgcairo.cabal
@@ -32,7 +32,7 @@ Source-Repository head
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 3.1,
+                 Cabal >= 1.24 && < 3.3,
                  gtk2hs-buildtools >= 0.13.2.0 && < 0.14
 
 Library
@@ -40,7 +40,9 @@ Library
                         glib  >=0.13.0.0 && <0.14,
                         cairo >=0.13.0.0 && <0.14
 
-        cpp-options:    -U__BLOCKS__ -D__attribute__(A)= -D_Nullable= -D_Nonnull=
+        cpp-options:    -DGLIB_DISABLE_DEPRECATION_WARNINGS -D_Nullable= -D_Nonnull= -D_Noreturn=
+        if os(darwin)
+          cpp-options:    -DGLIB_DISABLE_DEPRECATION_WARNINGS -D__attribute__(A)= -D_Nullable= -D_Nonnull= -D_Noreturn=
         exposed-modules:
           Graphics.Rendering.Cairo.SVG
 


### PR DESCRIPTION
This builds on https://github.com/gtk2hs/svgcairo/pull/10/commits/df6c6172b52ecbd32007529d86ba9913ba001306.

Patching `svgcairo` on nixpkgs with this commit fixed the linux build but removing one of the flags broke it for darwin. I don't think it's a nixpkgs issue and after some investigation I found similar issues on Github. It seems like we need to retain the `-D__attribute__(A)=` flag, so this adds it back with a `if os(darwin)` conditonal.