### PR TITLE
Update svgcairo to work with librsvg version 2.51.0 and greater

### DIFF
--- a/svgcairo.cabal
+++ b/svgcairo.cabal
@@ -49,4 +49,4 @@ Library
 
         Include-dirs: .
         x-c2hs-Header:  svgcairo.h
-        pkgconfig-depends: librsvg-2.0 >= 2.16.0
+        pkgconfig-depends: librsvg-2.0 >= 2.51.0

--- a/svgcairo.h
+++ b/svgcairo.h
@@ -3,4 +3,4 @@
 #endif
 #include <librsvg/rsvg.h>
 #include <librsvg/rsvg-cairo.h>
-#include <librsvg/librsvg-features.h>
+#include <librsvg/rsvg-features.h>


### PR DESCRIPTION
librsvg in nixpkgs was updated to version 2.52.0 recently which broke the svgcairo build because one of the headers is renamed in version 2.51.0.

This bumps the lower boundry for librsvg and updates the header's path.